### PR TITLE
[WIP] Create Unit Test pattern for NAPALM modules

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -228,7 +228,7 @@ def _config_logic(napalm_device,
 
 
 @proxy_napalm_wrap
-def connected(**kwarvs):  # pylint: disable=unused-argument
+def connected(**kwargs):  # pylint: disable=unused-argument
     '''
     Specifies if the connection to the device succeeded.
 

--- a/tests/unit/modules/test_napalm_network.py
+++ b/tests/unit/modules/test_napalm_network.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+from functools import wraps
+
+
+# Test data
+TEST_FACTS = {
+    'uptime': 'Forever',
+    'UP': True
+}
+
+TEST_ENVIRONMENT = {
+    'hot': 'yes'
+}
+
+
+class MockNapalmDevice(object):
+    '''Setup a mock device for our tests'''
+    def get_facts():
+        return TEST_FACTS
+
+    def get_environment():
+        return TEST_ENVIRONMENT
+
+    def get(key):
+        return TEST_FACTS[key]
+
+
+def mock_proxy_napalm_wrap(func):
+    '''
+    The proper decorator checks for proxy minions. We don't care
+    so just pass back to the origination function
+    '''
+
+    @wraps(func)
+    def func_wrapper(*args, **kwargs):
+        func.__globals__['napalm_device'] = MockNapalmDevice()
+        return func(*args, **kwargs)
+    return func_wrapper
+
+
+import salt.utils.napalm as napalm_utils
+napalm_utils.proxy_napalm_wrap = mock_proxy_napalm_wrap
+
+import salt.modules.napalm_network as napalm_network
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class NapalmNetworkModuleTestCase(TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        # TODO: Determine configuration best case
+        module_globals = {
+            '__salt__': {
+                'config.option': MagicMock(return_value={
+                    'test': {
+                        'driver': 'test',
+                        'key': '2orgk34kgk34g'
+                    }
+                })
+            }
+        }
+
+        return {napalm_network: module_globals}
+
+    def test_init(self):
+        with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
+            napalm_network.__init__("test")
+            dunder.assert_called_with('salt.modules.napalm_network')
+
+    def test_connected_pass(self):
+        ret = napalm_network.connected()
+        assert ret['out'] is True
+
+    def test_facts(self):
+        ret = napalm_network.facts()
+        assert ret == TEST_FACTS
+
+    def test_environment(self):
+        ret = napalm_network.environment()
+        assert ret == TEST_ENVIRONMENT
+
+    def test_cli_single_command(self):
+        '''
+        Test that CLI works with 1 arg
+        '''
+        ret = napalm_network.cli("show run")
+        assert ret == TEST_COMMAND_RESPONSE


### PR DESCRIPTION
Test Strategy is:
* Create a pattern where the module functions can be unit tested
* Have no dependency on NAPALM being installed
* Fix whether it is run in proxy or minion mode
* Only test the logic in the methods, nothing else (e.g. salt.utils.napalm)
* Not test private methods at this stage (although they have a lot of logic in them)